### PR TITLE
Spelling fixes for Arthur

### DIFF
--- a/hints.zil
+++ b/hints.zil
@@ -1240,7 +1240,7 @@ that can be called Glastonbury-ish.">
 "The following is a partial list of books I found useful and/or interesting
 in the creation of this game.||	FICTION:||	Le Morte D'Arthur, by Sir Thomas
 Mallory|	The History of the Kings of Britain, by Geoffrey of Monmouth|	Sir
-Gawain and the Green Knight, translated by J.R.R Tolkein|	The Once and
+Gawain and the Green Knight, translated by J.R.R Tolkien|	The Once and
 Future King, by T.H. White|	The Crystal Cave, by Mary Stewart|	The Hollow
 Hills, by Mary Stewart|	The Last Enchantment, by Mary Stewart|	The Wicked
 Day, by Mary Stewart|	The Acts of King Arthur & His Noble Knights, by John

--- a/hints.zil
+++ b/hints.zil
@@ -623,7 +623,7 @@ CH-KRAKEN
 		<PLTABLE
 CH-KRAKEN
 "How do I get the bracelet?"
-"The Kraken won't give it to you."
+"The kraken won't give it to you."
 "You'll have to take it from him."
 "You'll have to use violence."
 "You'll have to cut it off with your sword."

--- a/iknight.zil
+++ b/iknight.zil
@@ -85,7 +85,7 @@ later you feel ghostly fingers pluck at your clothing, and ">
 						(T
 							<TELL
 "|You hear the thunder of approaching hooves and suddenly a knight on
-horseback pulls up next ot you. Startled that you can see him, he wheels his
+horseback pulls up next to you. Startled that you can see him, he wheels his
 horse around, shouts, \"Tally ho!\" and gallops away again, leaving your
 possessions intact." CR>)>)>)
 		(<MC-CONTEXT? ,M-F-LOOK ,M-V-LOOK ,M-LOOK>

--- a/kitchen.zil
+++ b/kitchen.zil
@@ -768,7 +768,7 @@ tavern, and the farmers shoo you out into the town square."
 			<COND
 				(<MC-FORM? ,K-FORM-OWL>
 					<TELL
-"You flutter around the cage for a few moments, but don't make any progess." CR
+"You flutter around the cage for a few moments, but don't make any progress." CR
 					>
 				)
 				(<MC-FORM? ,K-FORM-SALAMANDER>

--- a/kitchen.zil
+++ b/kitchen.zil
@@ -442,7 +442,7 @@ cooked. Heh Heh.\"" CR
 						)
 						(T
 							<TELL
-"The cook fixes you with a viscious stare and says, \"If I ever find out who
+"The cook fixes you with a vicious stare and says, \"If I ever find out who
 opened that cage, I'll throttle him with my own hands.\"" CR
 							>
 						)

--- a/rednite.zil
+++ b/rednite.zil
@@ -59,7 +59,7 @@ lies to the west.|">
 					<COND
 						(<EQUAL? ,OHERE ,RM-FIELD-OF-HONOR>
 							<TELL
-"at attention before you, staring off into the distance. He acknowleges
+"at attention before you, staring off into the distance. He acknowledges
 your presence enough to say,">)
 						(T
 							<TELL

--- a/sword.zil
+++ b/sword.zil
@@ -639,7 +639,7 @@ CR The ,CH-BLACK-KNIGHT " takes advantage of your inactivity to ">)>
 							<RT-END-OF-GAME>)
 						(T
 							<TELL
-"launch a suprise attack. He feints a blow to your head, and then suddenly
+"launch a surprise attack. He feints a blow to your head, and then suddenly
 whirls and deals you a fatal blow across your midsection.|">
 							<RT-END-OF-GAME>)>)
 				(T


### PR DESCRIPTION
These are the spelling fixes for Arthur from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.

A few typos of the typos I reported back then have already been fixed in this version. That's a good thing!